### PR TITLE
added cherrypy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 twisted
 redis_protocol
 fakeredis
+cherrypy


### PR DESCRIPTION
Without cherrypy, this error happens:

```
(env)root@server:/opt/nosqlpot# python nosqlpot.py -deploy redis -out redis.log
Traceback (most recent call last):
  File "nosqlpot.py", line 19, in <module>
    from couchpot import couchdeploy
  File "/opt/nosqlpot/couchpot/__init__.py", line 1, in <module>
    from couchdeploy import coudeploy
  File "/opt/nosqlpot/couchpot/couchdeploy.py", line 1, in <module>
    import cherrypy
ImportError: No module named cherrypy
```