### PR TITLE
Fix: local variable 'command' referenced before assignment

### DIFF
--- a/redispot/redisdeploy.py
+++ b/redispot/redisdeploy.py
@@ -42,6 +42,7 @@ class RedisServer(Protocol):
             print str(command)
         except:
             data=rcvdata
+	    command=rcvdata
         if command.lower == "quit":
             self.transport.loseConnection()
 

--- a/redispot/redisdeploy.py
+++ b/redispot/redisdeploy.py
@@ -42,7 +42,7 @@ class RedisServer(Protocol):
             print str(command)
         except:
             data=rcvdata
-	    command=rcvdata
+            command=rcvdata
         if command.lower == "quit":
             self.transport.loseConnection()
 


### PR DESCRIPTION
Fix "exceptions.UnboundLocalError: local variable 'command' referenced before assignment"